### PR TITLE
Add sync workflow for ms-createpatient to domain repository

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,47 @@
+name: Sync ms-createpatients to Domain Repository
+
+on:
+  push:
+    branches:
+      - QA
+      - Dev
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout microservice repository
+        uses: actions/checkout@v3
+
+      - name: Get list of changed files
+        id: changed_files
+        run: |
+          git fetch origin ${{ github.ref_name }}
+          echo "CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | tr '\n' ' ')" >> $GITHUB_ENV
+
+      - name: Checkout domain repository
+        uses: actions/checkout@v3
+        with:
+          repository: DavidSebas20/domain-patient-management
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          path: domain_repo
+
+      - name: Copy microservice to domain repository
+        run: |
+          rm -rf domain_repo/ms-createpatients
+          mkdir -p domain_repo/ms-createpatients
+          cp -r . domain_repo/ms-createpatients/
+
+      - name: Commit and push changes
+        run: |
+          cd domain_repo
+          git config --global user.email "davidsebastian20@outlook.com"
+          git config --global user.name "DavidSebas20"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "Sync ms-createpatients: ${{ env.CHANGED_FILES }}"
+          git push origin ${{ github.ref_name }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -31,7 +31,18 @@ jobs:
         run: |
           rm -rf domain_repo/ms-createpatient
           mkdir -p domain_repo/ms-createpatient
-          cp -r $(ls -A | grep -v 'domain_repo') domain_repo/ms-createpatient/
+          rsync -av --exclude='.git' . domain_repo/ms-createpatient/
+       
+      - name: Ensure branch exists in domain repository
+        run: |
+          cd domain_repo
+          git fetch origin
+          if ! git show-ref --verify --quiet refs/heads/${{ github.ref_name }}; then
+            git checkout -b ${{ github.ref_name }}
+            git push origin ${{ github.ref_name }}
+          else
+            git checkout ${{ github.ref_name }}
+          fi
 
       - name: Commit and push changes
         run: |
@@ -43,5 +54,5 @@ jobs:
             echo "No changes to commit."
             exit 0
           fi
-          git commit -m "Sync ms-createpatients: ${{ env.CHANGED_FILES }}"
+          git commit -m "Sync ms-createpatient: ${{ env.CHANGED_FILES }}"
           git push origin ${{ github.ref_name }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,9 +29,9 @@ jobs:
 
       - name: Copy microservice to domain repository
         run: |
-          rm -rf domain_repo/ms-createpatients
-          mkdir -p domain_repo/ms-createpatients
-          cp -r $(ls -A | grep -v 'domain_repo') domain_repo/ms-createpatients/
+          rm -rf domain_repo/ms-createpatient
+          mkdir -p domain_repo/ms-createpatient
+          cp -r $(ls -A | grep -v 'domain_repo') domain_repo/ms-createpatient/
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           rm -rf domain_repo/ms-createpatients
           mkdir -p domain_repo/ms-createpatients
-          cp -r . domain_repo/ms-createpatients/
+          cp -r $(ls -A | grep -v 'domain_repo') domain_repo/ms-createpatients/
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
Implement a GitHub Actions workflow to synchronize the ms-createpatient microservice with the domain repository, ensuring proper branch handling and excluding unnecessary files during the copy process.